### PR TITLE
Add support for goog.module

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -157,8 +157,8 @@ Manager.prototype.getDependencies = function(opt_main) {
         }
         providesLookup[provide] = script;
       });
-      if (script.provides.length === 0 && script.requires.length === 0 &&
-          script.addsDependencies) {
+      if (script.addsDependencies && script.provides.length === 0 &&
+          script.requires.length === 0) {
         depsOnly.push(script);
       }
     });

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -130,6 +130,47 @@ var requireNode = {
 
 
 /**
+ * Statement with goog.module call.
+ * @type {Object}
+ */
+var moduleNode = {
+  type: 'ExpressionStatement',
+  start: '*',
+  end: '*',
+  expression: {
+    type: 'CallExpression',
+    start: '*',
+    end: '*',
+    callee: {
+      type: 'MemberExpression',
+      start: '*',
+      end: '*',
+      object: {
+        type: 'Identifier',
+        start: '*',
+        end: '*',
+        name: 'goog'
+      },
+      property: {
+        type: 'Identifier',
+        start: '*',
+        end: '*',
+        name: 'module'
+      },
+      computed: false
+    },
+    arguments: [{
+      type: 'Literal',
+      start: '*',
+      end: '*',
+      value: '*',
+      raw: '*'
+    }]
+  }
+};
+
+
+/**
  * Statement with goog.addDependency call.
  * @type {Object}
  */
@@ -276,6 +317,8 @@ Script.prototype._getProvides = function() {
   var base = false;
   var provides = this._ast.body.reduce(function(provides, statement) {
     if (like(statement, provideNode)) {
+      provides.push(statement.expression.arguments[0].value);
+    } else if (like(statement, moduleNode)) {
       provides.push(statement.expression.arguments[0].value);
     } else if (like(statement, googNode)) {
       base = true;

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -130,6 +130,63 @@ var requireNode = {
 
 
 /**
+ * Statement with goog.require call in a declaration.
+ * @type {Object}
+ */
+var requireNodeDeclaration = {
+  type: 'VariableDeclaration',
+  start: '*',
+  end: '*',
+  declarations: [
+    {
+      type: 'VariableDeclarator',
+      start: '*',
+      end: '*',
+      id: {
+        type: 'Identifier',
+        start: '*',
+        end: '*',
+        name: '*'
+      },
+      init: {
+        type: 'CallExpression',
+        start: '*',
+        end: '*',
+        callee: {
+          type: 'MemberExpression',
+          start: '*',
+          end: '*',
+          object: {
+            type: 'Identifier',
+            start: '*',
+            end: '*',
+            name: 'goog'
+          },
+          property: {
+            type: 'Identifier',
+            start: '*',
+            end: '*',
+            name: 'require'
+          },
+          computed: false
+        },
+        arguments: [
+          {
+            type: 'Literal',
+            start: '*',
+            end: '*',
+            value: '*',
+            raw: '*'
+          }
+        ]
+      }
+    }
+  ],
+  kind: 'var'
+};
+
+
+/**
  * Statement with goog.module call.
  * @type {Object}
  */
@@ -355,6 +412,8 @@ Script.prototype._getRequires = function() {
   return this._ast.body.reduce(function(requires, statement) {
     if (like(statement, requireNode)) {
       requires.push(statement.expression.arguments[0].value);
+    } else if (like(statement, requireNodeDeclaration)) {
+      requires.push(statement.declarations[0].init.arguments[0].value);
     }
     return requires;
   }, []);

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -336,6 +336,12 @@ var Script = exports.Script = function Script(config) {
   this._provides = null;
 
   /**
+   * Module.
+   * @type {boolean}
+   */
+  this._module = false;
+
+  /**
    * Requires array.
    * @type {Array.<string>}
    */
@@ -367,16 +373,18 @@ Object.defineProperty(Script.prototype, 'addsDependencies', {
 
 
 /**
- * Get provides.
- * @return {Array.<string>} List of arguments to goog.provide calls.
+ * Set provides and module.
  */
-Script.prototype._getProvides = function() {
+Script.prototype._setProvidesAndModule = function() {
   var base = false;
-  var provides = this._ast.body.reduce(function(provides, statement) {
+  var provides = [];
+  var module = false;
+  this._ast.body.reduce(function(unused, statement) {
     if (like(statement, provideNode)) {
       provides.push(statement.expression.arguments[0].value);
     } else if (like(statement, moduleNode)) {
       provides.push(statement.expression.arguments[0].value);
+      module = true;
     } else if (like(statement, googNode)) {
       base = true;
     }
@@ -389,17 +397,30 @@ Script.prototype._getProvides = function() {
     }
     provides = ['goog'];
   }
-  return provides;
+
+  this._provides = provides;
+  this._module = module;
 };
 
 
-Object.defineProperty(Script.prototype, 'provides', {
-  enumerable: true,
-  get: function() {
-    if (!this._provides) {
-      this._provides = this._getProvides();
+Object.defineProperties(Script.prototype, {
+  'provides': {
+    enumerable: true,
+    get: function() {
+      if (!this._provides) {
+        this._setProvidesAndModule();
+      }
+      return this._provides;
     }
-    return this._provides;
+  },
+  'module': {
+    enumerable: true,
+    get: function() {
+      if (!this._provides) {
+        this._setProvidesAndModule();
+      }
+      return this._module;
+    }
   }
 });
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -165,6 +165,10 @@ Server.prototype._requestListener = function(req, res) {
         res.writeHead(404, {});
         res.end('Script not being managed: ' + filepath);
       } else {
+        if (script.module) {
+          script.source = 'goog.loadModule(function(exports){ "use strict";' +
+            script.source + '\n;return exports;});\n';
+        }
         res.writeHead(200, {
           'Content-Type': 'application/javascript',
           'Content-Length': script.source.length

--- a/test/fixtures/dependencies-goog.module/goog/base.js
+++ b/test/fixtures/dependencies-goog.module/goog/base.js
@@ -1,0 +1,1 @@
+var goog = goog || {};

--- a/test/fixtures/dependencies-goog.module/lib/common/fuel.js
+++ b/test/fixtures/dependencies-goog.module/lib/common/fuel.js
@@ -1,0 +1,1 @@
+goog.module('fuel');

--- a/test/fixtures/dependencies-goog.module/lib/vehicle/boat.js
+++ b/test/fixtures/dependencies-goog.module/lib/vehicle/boat.js
@@ -1,0 +1,3 @@
+goog.module('boat');
+
+goog.require('vehicle');

--- a/test/fixtures/dependencies-goog.module/lib/vehicle/boat.js
+++ b/test/fixtures/dependencies-goog.module/lib/vehicle/boat.js
@@ -1,3 +1,5 @@
 goog.module('boat');
 
-goog.require('vehicle');
+// ES6 style require using an assignation. This style is made possible
+// by the use of goog.module in the vehicule file.
+var Vehicule = goog.require('vehicle');

--- a/test/fixtures/dependencies-goog.module/lib/vehicle/car.js
+++ b/test/fixtures/dependencies-goog.module/lib/vehicle/car.js
@@ -1,0 +1,3 @@
+goog.module('car');
+
+goog.require('vehicle');

--- a/test/fixtures/dependencies-goog.module/lib/vehicle/truck.js
+++ b/test/fixtures/dependencies-goog.module/lib/vehicle/truck.js
@@ -1,0 +1,3 @@
+goog.module('truck');
+
+goog.require('vehicle');

--- a/test/fixtures/dependencies-goog.module/lib/vehicle/vehicle.js
+++ b/test/fixtures/dependencies-goog.module/lib/vehicle/vehicle.js
@@ -1,0 +1,3 @@
+goog.module('vehicle');
+
+goog.require('fuel');

--- a/test/fixtures/dependencies-goog.module/main-boat.js
+++ b/test/fixtures/dependencies-goog.module/main-boat.js
@@ -1,0 +1,1 @@
+goog.require('boat');

--- a/test/fixtures/dependencies-goog.module/main-car.js
+++ b/test/fixtures/dependencies-goog.module/main-car.js
@@ -1,0 +1,1 @@
+goog.require('car');

--- a/test/spec/manager.spec.js
+++ b/test/spec/manager.spec.js
@@ -230,5 +230,48 @@ describe('manager', function() {
 
     });
 
+    describe('#getDependencies() with goog.module', function() {
+
+      it('provides dependencies for a main script (car)', function(done) {
+        var manager = new Manager({
+          closure: false,
+          cwd: fixtures,
+          lib: 'dependencies-goog.module/+(lib|goog)/**/*.js',
+          main: 'dependencies-goog.module/main-*.js'
+        });
+        manager.on('error', done);
+        manager.on('ready', function() {
+          var dependencies = manager.getDependencies(
+              path.join(fixtures, 'dependencies-goog.module', 'main-car.js'));
+          var paths = dependencies.map(function(s) {
+            return path.basename(s.path);
+          });
+          assert.deepEqual(paths,
+              ['base.js', 'fuel.js', 'vehicle.js', 'car.js', 'main-car.js']);
+          done();
+        });
+      });
+
+      it('provides dependencies for a main script (boat)', function(done) {
+        var manager = new Manager({
+          closure: false,
+          cwd: fixtures,
+          lib: 'dependencies-goog.module/+(lib|goog)/**/*.js',
+          main: 'dependencies-goog.module/main-*.js'
+        });
+        manager.on('error', done);
+        manager.on('ready', function() {
+          var dependencies = manager.getDependencies(
+              path.join(fixtures, 'dependencies-goog.module', 'main-boat.js'));
+          var paths = dependencies.map(function(s) {
+            return path.basename(s.path);
+          });
+          assert.deepEqual(paths,
+              ['base.js', 'fuel.js', 'vehicle.js', 'boat.js', 'main-boat.js']);
+          done();
+        });
+      });
+    });
+
   });
 });


### PR DESCRIPTION
This PR adds support for [goog.module](https://github.com/google/closure-library/wiki/goog.module:-an-ES6-module-like-alternative-to-goog.provide) in `closure-util`.

With this change, projects depending on `closure-util` for building their code can start experimenting/porting to an ES6-like module format.

Closure-util is modified to:
- recognize `goog.module` as a kind of `goog.provide`;
- serve `goog.module` code wrapped according to the specification;
- add `goog.module` tests.

This is a copy from the upstream PR https://github.com/openlayers/closure-util/pull/267.